### PR TITLE
HTTP and HTTPS mode, Document array support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # Ignore the built app binary
 bin/app
+app/ssl/*.pem

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,10 +26,12 @@ RUN useradd -rM appuser && \
 COPY /app /usr/src/app
 
 RUN mkdir /app && \
+    mkdir /app/ssl && \
     cd /usr/src/app && \
     go build -v -o /app/app && \
-    chown -R appuser:appuser /app && \
-    cp key.pem cert.pem /app
+    chown -R appuser:appuser /app
+
+VOLUME /app/ssl
 
 USER appuser
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,8 @@ COPY /app /usr/src/app
 RUN mkdir /app && \
     cd /usr/src/app && \
     go build -v -o /app/app && \
-    chown -R appuser:appuser /app
+    chown -R appuser:appuser /app && \
+    cp key.pem cert.pem /app
 
 USER appuser
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.4
+FROM golang:1.7
 
 MAINTAINER Potiguar Faga <potz@potz.me>
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,4 +37,7 @@ USER appuser
 WORKDIR /app
 EXPOSE 3000
 
-CMD [ "/app/app" ]
+# whether to run under SSL or not
+ENV SECURE true
+
+CMD ["/app/app"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,8 @@ RUN useradd -rM appuser && \
 
 COPY /app /usr/src/app
 
+RUN go get github.com/unidoc/unidoc
+
 RUN mkdir /app && \
     mkdir /app/ssl && \
     cd /usr/src/app && \
@@ -41,3 +43,4 @@ EXPOSE 3000
 ENV SECURE true
 
 CMD ["/app/app"]
+

--- a/README.md
+++ b/README.md
@@ -4,56 +4,91 @@ A dockerized webservice written in [Go](https://golang.org/) that uses [wkhtmlto
 
 ## Build & Run
 
-`docker build -t wkhtmltopdf . && docker run --rm -it -p 3000:3000 -v $(pwd)/app/ssl:/app/ssl wkhtmltopdf`
+HTTP: `docker build -t wkhtmltopdf . && docker run --rm -it -p 3000:3000 -e SECURE=false wkhtmltopdf`
+
+HTTPS: `docker build -t wkhtmltopdf . && docker run --rm -it -p 3000:3000 -v $(pwd)/app/ssl:/app/ssl wkhtmltopdf`
 
 For security purposes, we do not embed the SSL certificates in the image. Instead, mount a volume containing a cert.pem and key.pem to `/app/ssl`
 
 ## Usage
 
-The service listens on port 3000 for POST requests over SSL on the root path (`/`). Any other method returns a `405 not allowed` status. Any other path returns a `404 not found` status.
+The service listens on port 3000 for POST requests on the root path (`/`). Any other method returns a `405 not allowed` status. Any other path returns a `404 not found` status.
 
 The body should contain a JSON-encoded object containing the following parameters:
 
-One of:
-- **content**: The HTML/CSS to be converted.
-- **url**: The URL of the page to fetch and convert.
-
-And: 
 - **output**: The type of document to generate, can be either `jpg`, `png` or `pdf`. Defauts to `pdf` if not specified. Depending on the output type the appropriate binary is called.
-- **options**: A list of key-value arguments that are passed on to the appropriate `wkhtmltopdf` binary. Boolean values are interpreted as flag arguments (e.g.: `--greyscale`).
-- **cookies**: A list of key-value arguments that are passed on to the appropriate `wkhtmltopdf` binary as separate `cookie` arguments.
+- **requests**: An array of documents to be converted, each of which has the following parameters:
+
+  One of:
+  - **content**: The HTML/CSS to be converted.
+  - **url**: The URL of the page to fetch and convert.
+
+  And: 
+  - **options**: A list of key-value arguments that are passed on to the appropriate `wkhtmltopdf` binary. Boolean values are interpreted as flag arguments (e.g.: `--greyscale`).
+  - **cookies**: A list of key-value arguments that are passed on to the appropriate `wkhtmltopdf` binary as separate `cookie` arguments.
 
 **Example:** posting the following JSON:
 
 ```
 {
-  "url": "http://www.google.com",
-  "options": {
-    "margin-bottom": "1cm",
-    "orientation": "Landscape",
-    "grayscale": true
-  },
-  "cookies": {
-    "foo": "bar",
-    "baz": "foo"
-  }
+  "output": "pdf",
+  "requests": [
+    {
+      "content": "<html><body><h1>Google.com<\/h1><p>The HTML that would have been fetched<\/p><\/body><\/html>",
+      "options": {
+        "margin-bottom": "1cm",
+        "orientation": "Landscape",
+      },
+      "cookies": {
+        "foo": "bar",
+        "baz": "foo"
+      }
+    },
+    {
+      "url": "google.com",
+      "options": {
+        "margin-bottom": "1cm",
+        "orientation": "Landscape",
+        "grayscale": true
+      },
+      "cookies": {
+        "foo": "bar",
+        "baz": "foo"
+      }
+    },
+    {
+      "content": "<html><body><h1>Yahoo.com<\/h1><p>The HTML that would have been fetched<\/p><\/body><\/html>",
+      "options": {
+        "margin-bottom": "1cm",
+        "orientation": "Landscape",
+        "grayscale": true
+      },
+      "cookies": {
+        "foo": "bar",
+        "baz": "foo"
+      }
+    }
+  ]
 }
 ```
 
 will have the effect of the following command-line being executed on the server:
 
 ```
-/usr/local/bin/wkhtmltopdf --margin-bottom 1cm --orientation Landscape --grayscale --cookie foo bar --cookie baz foo http://www.google.com -
+echo "content" | /usr/local/bin/wkhtmltopdf --margin-bottom 1cm --orientation Landscape --grayscale --cookie foo bar --cookie baz foo - -
+/usr/local/bin/wkhtmltopdf --margin-bottom 1cm --orientation Landscape --cookie foo bar --cookie baz foo google.com -
+echo "content" | /usr/local/bin/wkhtmltopdf --margin-bottom 1cm --orientation Landscape --grayscale --cookie foo bar --cookie baz foo - -
 ```
 
 The `-` at the end of the command-line is so that the document contents are redirected to stdout so we can in turn redirect it to the web server's response stream.
 
-When using `jpg` or `png` output, the set of options you can pass are actually more limited. Please check [wkhtmltopdf usage docs](http://wkhtmltopdf.org/docs.html) or rather just use `wkhtmltopdf --help` or `wkhtmltoimage --help` to get help on the available command-line arguments.
+When using `jpg` or `png` output, the set of options you can pass are actually more limited. Please check [wkhtmltopdf usage docs](http://wkhtmltopdf.org/docs.html) or rather just use `wkhtmltopdf --help` or `wkhtmltoimage --help` to get help on the available command-line arguments. `jpg` and `png` only process the first element of the requests array.
 
 You can also pass in the HTML/CSS directly like so:
 
 ```
-{
+{"output": "pdf",
+ "requests": [{
   "content": "<html><body><h1>My Web Page<\/h1><p>The HTML that would have been fetched<\/p><\/body><\/html>",
   "options": {
     "margin-bottom": "1cm",
@@ -64,6 +99,7 @@ You can also pass in the HTML/CSS directly like so:
     "foo": "bar",
     "baz": "foo"
   }
+}]
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -2,13 +2,23 @@
 
 A dockerized webservice written in [Go](https://golang.org/) that uses [wkhtmltopdf](http://wkhtmltopdf.org/) to convert HTML into documents (images or pdf files).
 
+## Build & Run
+
+`docker build -t wkhtmltopdf . && docker run --rm -it -p 3000:3000 -v $(pwd)/app/ssl:/app/ssl wkhtmltopdf`
+
+For security purposes, we do not embed the SSL certificates in the image. Instead, mount a volume containing a cert.pem and key.pem to `/app/ssl`
+
 ## Usage
 
-The service listens on port 3000 for POST requests on the root path (`/`). Any other method returns a `405 not allowed` status. Any other path returns a `404 not found` status.
+The service listens on port 3000 for POST requests over SSL on the root path (`/`). Any other method returns a `405 not allowed` status. Any other path returns a `404 not found` status.
 
 The body should contain a JSON-encoded object containing the following parameters:
 
-- **url**: The URL of the page to convert.
+One of:
+- **content**: The HTML/CSS to be converted.
+- **url**: The URL of the page to fetch and convert.
+
+And: 
 - **output**: The type of document to generate, can be either `jpg`, `png` or `pdf`. Defauts to `pdf` if not specified. Depending on the output type the appropriate binary is called.
 - **options**: A list of key-value arguments that are passed on to the appropriate `wkhtmltopdf` binary. Boolean values are interpreted as flag arguments (e.g.: `--greyscale`).
 - **cookies**: A list of key-value arguments that are passed on to the appropriate `wkhtmltopdf` binary as separate `cookie` arguments.
@@ -40,10 +50,26 @@ The `-` at the end of the command-line is so that the document contents are redi
 
 When using `jpg` or `png` output, the set of options you can pass are actually more limited. Please check [wkhtmltopdf usage docs](http://wkhtmltopdf.org/docs.html) or rather just use `wkhtmltopdf --help` or `wkhtmltoimage --help` to get help on the available command-line arguments.
 
+You can also pass in the HTML/CSS directly like so:
+
+```
+{
+  "content": "<html><body><h1>My Web Page<\/h1><p>The HTML that would have been fetched<\/p><\/body><\/html>",
+  "options": {
+    "margin-bottom": "1cm",
+    "orientation": "Landscape",
+    "grayscale": true
+  },
+  "cookies": {
+    "foo": "bar",
+    "baz": "foo"
+  }
+}
+```
 
 ## Known limitations / TODOs
 
-This service doesn't currently accept or convert raw HTML. We found that it's difficult to render raw HTML when you have relative links in the page. There are known workarounds that we haven't yet tried (see [this stack overflow question](http://stackoverflow.com/questions/21775572/wkhtmltopdf-relative-paths-in-html-with-redirected-in-out-streams-wont-work) for more information).
+There are challenges with converting raw HTML when you have relative links. There are known workarounds that we haven't yet tried (see [this stack overflow question](http://stackoverflow.com/questions/21775572/wkhtmltopdf-relative-paths-in-html-with-redirected-in-out-streams-wont-work) for more information).
 
 The server currently does not check if the arguments are valid, just passes them on to the `wkhtmltopdf` and `wkhtmltoimage` binaries. If you pass a wrong argument you don't currently get an error, just an empty image or pdf back.
 

--- a/app/app.go
+++ b/app/app.go
@@ -15,10 +15,21 @@ import (
 
 func main() {
 	const bindAddress = ":3000"
+	secure := strings.ToLower(strings.TrimSpace(os.Getenv("SECURE")))
+	if secure == "" {
+		secure = "true"
+	}
+
 	http.HandleFunc("/", requestHandler)
-	fmt.Println("Http server listening on", bindAddress)
 	baseDir := filepath.Dir(os.Args[0])
-	err := http.ListenAndServeTLS(bindAddress, filepath.Join(baseDir, "ssl/cert.pem"), filepath.Join(baseDir, "ssl/key.pem"), nil)
+	var err error
+	if secure == "false" {
+		fmt.Println("INSECURE http server listening on", bindAddress)
+		err = http.ListenAndServe(bindAddress, nil)
+	} else {
+		fmt.Println("Secure https server listening on", bindAddress)
+		err = http.ListenAndServeTLS(bindAddress, filepath.Join(baseDir, "ssl/cert.pem"), filepath.Join(baseDir, "ssl/key.pem"), nil)
+	}
 	if err != nil {
 		log.Panic(err)
 	}

--- a/app/app.go
+++ b/app/app.go
@@ -18,7 +18,7 @@ func main() {
 	http.HandleFunc("/", requestHandler)
 	fmt.Println("Http server listening on", bindAddress)
 	baseDir := filepath.Dir(os.Args[0])
-	err := http.ListenAndServeTLS(bindAddress, filepath.Join(baseDir, "cert.pem"), filepath.Join(baseDir, "key.pem"), nil)
+	err := http.ListenAndServeTLS(bindAddress, filepath.Join(baseDir, "ssl/cert.pem"), filepath.Join(baseDir, "ssl/key.pem"), nil)
 	if err != nil {
 		log.Panic(err)
 	}


### PR DESCRIPTION
Not sure if you're interested in taking PRs as this is a fair bit different than your service. 

This allows the container to run under HTTPS or HTTP (good for local testing) and accept HTML/CSS directly for rendering. We also added document array support so you can pass in multiple documents/URLs, each with their own configs, and get back a single PDF to build more complex documents. For images, it just uses the first element in the array.